### PR TITLE
Add Special Character Device Name Fix

### DIFF
--- a/api/models/server.js
+++ b/api/models/server.js
@@ -383,10 +383,15 @@ function translateAPIDeviceToDatabaseObject(device, serverId, type){
   } else {
     lastDate = device.report_date_utc;
   }
-  var dbObject = {"server_id" : serverId, "device_type" : type, "jss_id" : device.id, "jss_name" : device.name,
+  var dbObject = {"server_id" : serverId, "device_type" : type, "jss_id" : device.id, "jss_name" : cleanInput(device.name),
                   "jss_serial" : device.serial_number, "jss_last_inventory" : lastDate,
                   "jss_model" : device.model, "jss_managed" : device.managed, "jss_udid" : device.udid};
   return dbObject;
+}
+
+function cleanInput(dirtyString) {
+  // clean non-ascii characters from string
+  return dirtyString.replace(/[^\x00-\x7F]/g, "");
 }
 
 exports.getAllDevices = function(url, serverId, username, password){


### PR DESCRIPTION
Cleans the input of the device name from pesky non-ASCII characters.

Example: 
iOS device in jamfPro.
![iOS Device in jamfPro](https://user-images.githubusercontent.com/17804548/62091349-07c77100-b236-11e9-883d-6f109270a29a.png)

iOS device in Scout:
![Screen Shot 2019-07-29 at 7 18 30 PM](https://user-images.githubusercontent.com/17804548/62091376-2a598a00-b236-11e9-99cf-4ca4a0fb0fb9.png)


Resolves #1 