### PR TITLE
Add Error Logging

### DIFF
--- a/api/common/logger.js
+++ b/api/common/logger.js
@@ -5,7 +5,9 @@ const logger = createLogger({
     format: combine(format.timestamp(), format.json()),
     transports: [
       // - Write to all access logs with level `info`
-      new transports.File({ filename: process.env.ROOT_DIR+'logs/access.log', level: 'info' })
+      new transports.File({ filename: process.env.ROOT_DIR+'logs/access.log', level: 'info' }),
+      // - Write all error logs with level `error`
+      new transports.File({ filename: process.env.ROOT_DIR+'logs/error.log', level: 'error' })
     ]
 });
 
@@ -14,4 +16,11 @@ exports.logActivity = function(auditObj) {
         level: "info",
         ...auditObj
     });
+}
+
+exports.logError = function(errorObj) {
+    logger.log({
+        level: "error",
+        ...errorObj
+    })
 }

--- a/api/controllers/admin.js
+++ b/api/controllers/admin.js
@@ -5,7 +5,8 @@ var admin = require('../models/admin.js');
 var crontab = require('cron-tab');
 var cron = require('../common/cron-handler.js');
 var servers = require('../models/server.js');
-var audit = require('../common/audit-logger.js').logActivity;
+var audit = require('../common/logger.js').logActivity;
+var logError = require('../common/logger.js').logError;
 
 adminController.get('/organization/details', function(req,res){
   //try to get the org name from the env settings
@@ -20,6 +21,7 @@ adminController.get('/organization/details', function(req,res){
         // Get the current cron jobs related to scout
         crontab.load(function(err, crontab){
           if (err) {
+            logError({message: "Unable to read server settings.", user: req.user, error: err});
             return res.status(500).send({ error : 'Unable to read server settings.'});
           }
           let responseObject = { header_name : process.env.HEADER_DISPLAY_NAME};
@@ -30,6 +32,7 @@ adminController.get('/organization/details', function(req,res){
     }
   } catch (exc){
     console.log(exc);
+    logError({message: "Unable to read server settings.", user: req.user, error: exc});
     return res.status(500).send({ error : 'Unable to read server settings.'});
   }
 });
@@ -49,6 +52,7 @@ adminController.get('/all', function(req,res){
     return res.status(200).send(settings);
   })
   .catch(error => {
+    logError({message: "Unable to read settings.", user: req.user, error});
     return res.status(500).send({error: "Unable to read settings"});
   });
 });
@@ -72,6 +76,7 @@ adminController.put('/user', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to update user record.", user: req.user, error});
     return res.status(500).send({error : "Unable to update user record"});
   });
 })
@@ -93,6 +98,7 @@ adminController.put('/all', function(req,res){
     return res.status(200).send({status : "success"});
   })
   .catch(error => {
+    logError({message: "Unable to update file.", user: req.user, error});
     return res.status(500).send({error : "Unable to update file"});
   });
 });
@@ -114,10 +120,12 @@ adminController.put('/cronjobs', function(req,res) {
       return res.status(200).send({status : "success"});
     })
     .catch(function(error){
+      logError({message: "Unable to verify cron jobs.", user: req.user, error});
       return res.status(500).send({error : 'Unable to verify cron jobs'});
     });
   })
   .catch(function(error){
+    logError({message: "Unable to verify cron jobs.", user: req.user, error});
     return res.status(500).send({error : 'Unable to verify cron jobs'});
   });
 });

--- a/api/controllers/commands.js
+++ b/api/controllers/commands.js
@@ -1,7 +1,8 @@
 var commands = require('express').Router();
 var device = require('../models/device.js');
 var db = require('../common/db.js');
-var audit = require('../common/audit-logger').logActivity;
+var audit = require('../common/logger.js').logActivity;
+var logError = require('../common/logger.js').logError;
 
 commands.post('/create/:platform', function(req,res) {
   //Make sure the user has permissions
@@ -26,6 +27,7 @@ commands.post('/create/:platform', function(req,res) {
     return res.status(200).send({ status : "success" });
   })
   .catch(error => {
+    logError({message: "Failed to send MDM command to devices.", user: req.user, error});
     //Show some helpful errors if it's an error from the JSS
     if ('req_data' in error && 'url' in error && 'res_data' in error){
       return res.status(500).send({ status : "failed", error : error});

--- a/api/controllers/devices.js
+++ b/api/controllers/devices.js
@@ -7,7 +7,8 @@ var server = require('../models/server.js');
 var inventory = require('../models/inventory.js');
 var user = require('../models/user.js');
 var db = require('../common/db.js');
-var audit = require('../common/audit-logger.js').logActivity;
+var audit = require('../common/logger.js').logActivity;
+var logError = require('../common/logger.js').logError;
 
 devices.get('/server/:orgName', function(req,res) {
   device.getDevicesByOrg(req.params.orgName)
@@ -17,6 +18,7 @@ devices.get('/server/:orgName', function(req,res) {
     });
   })
   .catch(error => {
+    logError({message: "Unable to get devices.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get devices"
     });
@@ -48,16 +50,19 @@ devices.put('/refresh/all', function(req,res){
       })
       .catch(error => {
         console.log(error);
+        logError({message: "Unable to upsert new device records.", user: req.user, error});
         return res.status(500).send({ error: "Unable to upsert new device records"});
       });
     })
     .catch(error => {
       console.log(error);
+      logError({message: "Unable to get devices from Jamf Pro Server", user: req.user, error});
       return res.status(500).send({ error: "Unable to get devices from Jamf Pro Server "});
     });
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to get list of servers.", user: req.user, error});
     return res.status(500).send({ error: "Unable to get list of servers"});
   });
 });
@@ -72,6 +77,7 @@ devices.post('/paged/:deviceType', function(req,res) {
     return res.status(200).send(obj);
   })
   .catch(error => {
+    logError({message: "Unable to get devices.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get devices"
     });
@@ -102,6 +108,7 @@ devices.get('/', function(req,res) {
     });
   })
   .catch(error => {
+    logError({message: "Unable to get devices.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get devices"
     });
@@ -115,6 +122,7 @@ devices.get('/csv', function(req,res) {
     return res.status(200).send({ "status" : "success", "path" : process.env.SCOUT_URL + stream.path.substring(1,stream.path.length)});
   })
   .catch(error => {
+    logError({message: "Unable to write csv file.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to write file"
     });
@@ -128,6 +136,7 @@ devices.get('/computers/expanded/:id', function(req,res){
     return res.status(200).send(result);
   })
   .catch(error => {
+    logError({message: "Unable to find device record.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to find device record"
     });
@@ -148,12 +157,14 @@ devices.post('/live/:collection', function(req,res){
       return res.status(200).send(jpsAPIResponse);
     })
     .catch(error => {
+      logError({message: "Unable to hit the JPS API for this device.", user: req.user, error});
       return res.status(500).send({
         error: "Unable to hit the JPS API for this device"
       });
     });
   })
   .catch(error => {
+    logError({message: "Unable to find device record.", user: req.user, error});
     return res.status(400).send({
       error: "Unable to find device record"
     });
@@ -171,12 +182,14 @@ devices.get('/live/:collection/:id', function(req,res){
       return res.status(200).send(jpsAPIResponse);
     })
     .catch(error => {
+      logError({message: "Unable to hit the JPS API for this device.", user: req.user, error});
       return res.status(500).send({
         error: "Unable to hit the JPS API for this device"
       });
     });
   })
   .catch(error => {
+    logError({message: "Unable to find device record.", user: req.user, error});
     return res.status(400).send({
       error: "Unable to find device record"
     });
@@ -191,6 +204,7 @@ devices.get('/computers', function(req,res) {
     });
   })
   .catch(error => {
+    logError({message: "Unable to get devices.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get devices"
     });
@@ -205,6 +219,7 @@ devices.get('/mobiledevices', function(req,res) {
     });
   })
   .catch(error => {
+    logError({message: "Unable to get mobile devices.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get devices"
     });
@@ -219,6 +234,7 @@ devices.get('/tvs', function(req,res) {
     });
   })
   .catch(error => {
+    logError({message: "Unable to get tvs.", user: req.user, error});
     return res.status(500).send({ error: "Unable to get devices" });
   });
 });
@@ -229,6 +245,7 @@ devices.get('/count/:deviceType', function(req,res) {
     return res.status(200).send({ "size" : deviceList.length});
   })
   .catch(error => {
+    logError({message: "Unable to get device count.", user: req.user, error});
     return res.status(500).send({ error: "Unable to get devices" });
   });
 });
@@ -244,6 +261,7 @@ devices.delete('/id/:scoutDeviceId', function(req,res) {
     return res.status(200).send({status : 'success'});
   })
   .catch(error => {
+    logError({message: "Unable to delete device by scout id", user: req.user, error});
     return res.status(500).send({error : 'Unable to delete device by scout id'});
   });
 });

--- a/api/controllers/reports.js
+++ b/api/controllers/reports.js
@@ -1,7 +1,8 @@
 var reports = require('express').Router();
 var report = require('../models/reports.js');
 var user = require('../models/user.js');
-const audit = require('../common/audit-logger').logActivity;
+const audit = require('../common/logger.js').logActivity;
+const logError = require('../common/logger.js').logError;
 
 reports.get('/builder/fields', function(req,res) {
   //get all of the supported fields and their UI name
@@ -27,6 +28,7 @@ reports.get('/', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to get reports.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get reports"
     });
@@ -48,6 +50,7 @@ reports.get('/id/:reportId', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to get report.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get report"
     });
@@ -74,6 +77,7 @@ reports.delete('/id/:reportId', function(req,res){
     return res.status(200).send({status : 'success'});
   })
   .catch(error => {
+    logError({message: "Unable to delete report or it's line items.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to delete report or it's line items."
     });
@@ -113,6 +117,7 @@ reports.put('/update/:reportId', function(req,res){
     })
     .catch(error => {
       console.log(error);
+      logError({message: "Unable to update report line items.", user: req.user, error});
       return res.status(500).send({
         error: "Unable to update report line items"
       });
@@ -120,6 +125,7 @@ reports.put('/update/:reportId', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to update report.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to update report"
     });
@@ -164,6 +170,7 @@ reports.post('/save', function(req,res){
     })
     .catch(error => {
       console.log(error);
+      logError({message: "Unable to insert report line items.", user: req.user, error});
       return res.status(500).send({
         error: "Unable to insert report line items"
       });
@@ -171,6 +178,7 @@ reports.post('/save', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to insert new report.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to insert new report"
     });
@@ -205,6 +213,7 @@ reports.get('/search/:reportId', function(req,res){
     })
     .catch(error => {
       console.log(error);
+      logError({message: "Unable to perform search.", user: req.user, error});
       return res.status(500).send({
         error: "Unable to perform search"
       });
@@ -212,6 +221,7 @@ reports.get('/search/:reportId', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to get report.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get report"
     });
@@ -235,6 +245,7 @@ reports.post('/search', function(req,res) {
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to perform search.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to perform search"
     });

--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -5,7 +5,8 @@ var secretKey = process.env.JWT_KEY;
 var bcrypt = require('bcrypt-nodejs');
 var ldap = require('ldapjs');
 var jwttoken = require('jsonwebtoken');
-var audit = require('../common/audit-logger.js').logActivity;
+var audit = require('../common/logger.js').logActivity;
+var logError = require('../common/logger.js').logError;
 
 
 function createToken(user) {
@@ -48,6 +49,7 @@ users.get('/all', function(req,res){
   })
   .catch(error => {
     console.log(error);
+    logError({message: "Unable to get users.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to get users"
     });
@@ -86,6 +88,7 @@ users.post('/create', function(req, res) {
   .catch(error => {
     console.log('User Register Failed: ');
     console.log(error);
+    logError({message: "Unable to create users.", user: req.user, error});
     //Check for dupe user error
     if (error.hasOwnProperty('status')){
       return res.status(409).send({  error: "Email already exists"  });
@@ -133,6 +136,7 @@ users.post('/login/basic', function(req, res) {
     res.status(200).send(resp);
   })
   .catch(error => {
+    logError({message: "Unable to log in user.", user: req.user, error});
     console.error(error);
     return res.status(400).send({ error: "Unable to log in user"});
   });
@@ -166,6 +170,7 @@ users.post('/verify', function(req,res){
     return res.status(200).send({ verified : isVerified});
   })
   .catch(error => {
+    logError({message: "Unable to find user.", user: req.user, error});
     return res.status(500).send({
       error: "Unable to find user"
     });


### PR DESCRIPTION
This PR resolves #7. 

I changed the `audit-logger.js` file to just be `logger.js` and handle the error log as well as the access log. This should cover the errors. 

For the reports, I am pretty sure that the mongo error object that is returned will have some useful info; however, I don't think that I can get details about the reports if it's throwing an error when trying to get them.