### PR TITLE
Report on Extension Attributes

### DIFF
--- a/app/js/scripts.js
+++ b/app/js/scripts.js
@@ -358,9 +358,11 @@ function viewReportResults(reportId){
         var parentCategory = c.split(".")[0];
         var dataCategory = c.split(".")[1];
         if (parentCategory === 'extension_attributes') {
+          var val = ""
           res.results[i][deviceType][parentCategory].forEach(item => {
-            row.push(item[dataCategory])
+            val = val + item[dataCategory]
           })
+          row.push(val)
         } else {
           row.push(res.results[i][deviceType][parentCategory][dataCategory]);
         }

--- a/app/js/scripts.js
+++ b/app/js/scripts.js
@@ -357,7 +357,13 @@ function viewReportResults(reportId){
         c = c.replace(/\s/g,'');
         var parentCategory = c.split(".")[0];
         var dataCategory = c.split(".")[1];
-        row.push(res.results[i][deviceType][parentCategory][dataCategory]);
+        if (parentCategory === 'extension_attributes') {
+          res.results[i][deviceType][parentCategory].forEach(item => {
+            row.push(item[dataCategory])
+          })
+        } else {
+          row.push(res.results[i][deviceType][parentCategory][dataCategory]);
+        }
       });
       //Add a row for the device to the table
       resultTable.row.add(row);


### PR DESCRIPTION
For this one creating and storing the report fields is correct. The problem was in the datatables display of the queried data. `extension_attributes` is an array of objects.

Now when viewing the results, it checks to see if it's displaying `extension_attributes` if so, it loops over those values and adds them together into the row. This works for all the children of the `extension_attributes`.

- [x] We are able to generate accurate reports based on extension attribute status
- [x] We are able to update reports based on extension attribute status


Resolves #11 